### PR TITLE
Added Current method in TimeEntriesService (and its test)

### DIFF
--- a/toggl/time_entries.go
+++ b/toggl/time_entries.go
@@ -180,3 +180,19 @@ func (s *TimeEntriesService) List(start, end *time.Time) ([]TimeEntry, error) {
 
 	return *data, err
 }
+
+// Get running time entry.
+//
+// Toggl API docs: https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md#get-running-time-entry
+func (s *TimeEntriesService) Current() (*TimeEntry, error) {
+	u := "time_entries/current"
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	data := new(TimeEntryResponse)
+	_, err = s.client.Do(req, data)
+
+	return data.Data, err
+}

--- a/toggl/time_entries_test.go
+++ b/toggl/time_entries_test.go
@@ -181,3 +181,23 @@ func TestTimeEntriesService_List(t *testing.T) {
 		t.Errorf("TimeEntries.List returned %v, want %v", result, want)
 	}
 }
+
+func TestTimeEntriesService_Current(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/time_entries/current", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"data": {"id": 1}}`)
+	})
+
+	result, err := client.TimeEntries.Current()
+	if err != nil {
+		t.Errorf("TimeEntries.Current returned error: %v", err)
+	}
+
+	want := &TimeEntry{ID: 1}
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("TimeEntries.Current returned %v, want %v", result, want)
+	}
+}


### PR DESCRIPTION
This pull request adds a method for https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md#get-running-time-entry.

Thanks for publishing this nice library. I'm using this in [my project](https://github.com/vzvu3k6k/togglstack).
