### PR TITLE
Fixed wrong 'at' type.

### DIFF
--- a/toggl/time_entries.go
+++ b/toggl/time_entries.go
@@ -33,7 +33,7 @@ type TimeEntry struct {
 	CreatedWith string     `json:"created_with,omitempty"`
 	Tags        []string   `json:"tags,omitempty"`
 	Duronly     bool       `json:"duronly,omitempty"`
-	At          int        `json:"at,omitempty"`
+	At          *time.Time `json:"at,omitempty"`
 }
 
 // TimeEntryResponse acts as a response wrapper where response returns


### PR DESCRIPTION
The `at` value of a time entry is provided as a string like "2014-01-30T09:08:12+00:00". Parsing this value as `int` raises an error (<samp>json: cannot unmarshal string into Go value of type int</samp>).

Ref: https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md#get-time-entry-details
